### PR TITLE
Add a print_node helper and expose FFI

### DIFF
--- a/crates/core/c_src/include/LiveViewNativeCore.h
+++ b/crates/core/c_src/include/LiveViewNativeCore.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "Support.h"
+
+typedef uint32_t NodeRef;
+typedef uint32_t AttributeRef;
+
+typedef struct __Document {
+  void *ptr;
+} __Document;
+
+typedef struct __Element {
+  _RustStr ns;
+  _RustStr tag;
+  _RustSlice attributes;
+} __Element;
+
+typedef struct __Attribute {
+  _RustStr ns;
+  _RustStr name;
+  _RustStr value;
+} __Attribute;
+
+enum __NodeType {
+  NodeTypeRoot = 0,
+  NodeTypeElement = 1,
+  NodeTypeLeaf = 2,
+} __attribute__((enum_extensibility(closed)));
+
+typedef enum __NodeType __NodeType;
+
+typedef union __NodeData {
+  void *root;
+  __Element element;
+  _RustStr leaf;
+} __NodeData;
+
+typedef struct __Node {
+  __NodeType ty;
+  __NodeData data;
+} __Node;
+
+extern _RustString __liveview_native_core$Document$to_string(__Document doc);
+
+extern __Document __liveview_native_core$Document$empty();
+
+extern void __liveview_native_core$Document$drop(__Document doc);
+
+extern _RustResult __liveview_native_core$Document$parse(_RustStr text,
+                                                         _RustString *error);
+
+extern bool __liveview_native_core$Document$merge(__Document doc,
+                                                  __Document other);
+
+extern NodeRef __liveview_native_core$Document$root(__Document doc);
+
+extern __Node __liveview_native_core$Document$get(__Document doc, NodeRef node);
+
+extern _RustSlice __liveview_native_core$Document$children(__Document doc,
+                                                           NodeRef node);
+
+extern _RustSlice __liveview_native_core$Document$attributes(__Document doc,
+                                                             NodeRef node);
+
+extern __Attribute
+__liveview_native_core$Document$get_attribute(__Document doc,
+                                              AttributeRef attr);

--- a/crates/core/c_src/include/LiveViewNativeCore.h
+++ b/crates/core/c_src/include/LiveViewNativeCore.h
@@ -42,6 +42,8 @@ typedef struct __Node {
 
 extern _RustString __liveview_native_core$Document$to_string(__Document doc);
 
+extern _RustString __liveview_native_core$Document$node_to_string(__Document doc, NodeRef node);
+
 extern __Document __liveview_native_core$Document$empty();
 
 extern void __liveview_native_core$Document$drop(__Document doc);

--- a/crates/core/c_src/include/Support.h
+++ b/crates/core/c_src/include/Support.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <stdbool.h>
+
+#if defined(_WIN32)
+typedef unsigned char uint8_t;
+typedef uint8_t u_int8_t;
+typedef unsigned short uint16_t;
+typedef uint16_t u_int16_t;
+typedef unsigned uint32_t;
+typedef uint32_t u_int32_t;
+typedef unsigned long long uint64_t;
+typedef uint64_t u_int64_t;
+#else
+#include <stdint.h>
+#endif
+
+typedef struct _RustResult {
+  bool is_ok;
+  void *ok_result;
+} _RustResult;
+
+typedef struct _RustSlice {
+  const void *start;
+  uintptr_t len;
+} _RustSlice;
+
+typedef struct _RustStr {
+  const void *start;
+  uintptr_t len;
+} _RustStr;
+
+extern bool __liveview_native_core$RustStr$eq(_RustStr lhs, _RustStr rhs);
+extern bool __liveview_native_core$RustStr$lt(_RustStr lhs, _RustStr rhs);
+
+typedef struct _RustString {
+  const void *start;
+  uintptr_t len;
+  uintptr_t capacity;
+} _RustString;
+
+extern void __liveview_native_core$RustString$drop(_RustString string);

--- a/crates/core/c_src/include/module.modulemap
+++ b/crates/core/c_src/include/module.modulemap
@@ -1,0 +1,5 @@
+module liveview_native_core {
+    header "Support.h"
+    header "LiveViewNativeCore.h"
+    export *
+}

--- a/crates/core/src/dom/mod.rs
+++ b/crates/core/src/dom/mod.rs
@@ -557,7 +557,17 @@ impl Document {
 
     /// Prints this document using the given writer and options
     pub fn print(&self, writer: &mut dyn fmt::Write, options: PrintOptions) -> fmt::Result {
-        let printer = Printer::new(self, self.root, options);
+        self.print_node(self.root, writer, options)
+    }
+
+    /// Prints a node in this document using the given writer and options
+    pub fn print_node(
+        &self,
+        node: NodeRef,
+        writer: &mut dyn fmt::Write,
+        options: PrintOptions,
+    ) -> fmt::Result {
+        let printer = Printer::new(self, node, options);
         printer.print(writer)
     }
 }

--- a/crates/core/src/ffi/mod.rs
+++ b/crates/core/src/ffi/mod.rs
@@ -130,6 +130,15 @@ pub extern "C" fn document_to_string(doc: *mut dom::Document) -> RustString {
     RustString::from_string(doc.to_string())
 }
 
+#[export_name = "__liveview_native_core$Document$node_to_string"]
+pub extern "C" fn document_node_to_string(doc: *mut dom::Document, node: NodeRef) -> RustString {
+    let doc = unsafe { &*doc };
+    let mut buf = String::new();
+    doc.print_node(node, &mut buf, dom::PrintOptions::Pretty)
+        .expect("error printing node");
+    RustString::from_string(buf)
+}
+
 #[export_name = "__liveview_native_core$Document$merge"]
 pub extern "C" fn document_merge(doc: *mut dom::Document, other: *const dom::Document) -> bool {
     let doc = unsafe { &mut *doc };


### PR DESCRIPTION
Useful for debugging when you need to compare two nodes.

Also re-adds the C headers that were removed in 9966a1851a487479a6d829dd212850869ac9872e, but in the new location.