### PR TITLE
handle attr changes in simple case of 1 attr => 1 value

### DIFF
--- a/crates/core/src/diff/diff.rs
+++ b/crates/core/src/diff/diff.rs
@@ -498,6 +498,16 @@ fn diff_attributes(
             continue;
         }
 
+        // hack: handle a single changed initial value, until the todo below is done
+        if 1 == new_values.len() && old_values[0] != new_values[0] {
+            patches.push_back(Patch::UpdateAttribute {
+                node,
+                value: new_values[0].1.clone(),
+                name: diff.1,
+            });
+            continue;
+        }
+
         // Otherwise, for each value change, issue a patch to remove the old value and add the new
         todo!()
     }

--- a/crates/core/tests/diff.rs
+++ b/crates/core/tests/diff.rs
@@ -98,7 +98,7 @@ fn dom_swift_integration_test() {
     <head>
         <meta charset="utf-8" />
     </head>
-    <body class="new-value" class="main">
+    <body class="new-value" class="main" data-foo="old">
         some content
     </body>
 </html>
@@ -113,7 +113,7 @@ fn dom_swift_integration_test() {
         <meta charset="utf-8" />
         <meta name="title" content="Hello World" />
     </head>
-    <body class="new-value" class="main">
+    <body class="new-value" class="main" data-foo="new">
         new content
     </body>
 </html>


### PR DESCRIPTION
This PR adds support for changing an attributes' value -- in the common case, not the multiple-values case.

(I needed this because I have a LiveView that changes attributes, and I saw that this was a 'todo').

I marked it a draft because I see indications that LVNC aspires to handle multiple values for attributes -- an example used in the tests is web-inspired, like: `<body class="a" class="b"></body>`.

In the case of LiveViewNative it feels like you could just say "people, let's not do that", if you really wanted ...