### PR TITLE
Add watchOS build

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -126,8 +126,11 @@ args = [
 	# Universal iOS sim
     "-library", "${CARGO_TARGET_DIR}/universal-ios-sim-libliveview_native_core.a",
     "-headers", "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/crates/core/c_src/include",
+	# Universal watchOS
+    "-library", "${CARGO_TARGET_DIR}/universal-watchos-libliveview_native_core.a",
+    "-headers", "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/crates/core/c_src/include",
 ]
-dependencies = ["build-macos", "build-ios", "lipo-macos", "lipo-ios-sim", "remove-existing-xcframework"]
+dependencies = ["build-macos", "build-ios", "build-watchos", "lipo-macos", "lipo-ios-sim", "lipo-watchos", "remove-existing-xcframework"]
 
 [tasks.remove-existing-xcframework]
 workspace = false
@@ -149,6 +152,14 @@ category = "Build"
 description = "Compiles for all targets needed to produce a universal library for iOS"
 command = "rustup"
 args = ["run", "${CARGO_MAKE_TOOLCHAIN}", "cargo", "build", "@@remove-empty(CARGO_MAKE_CARGO_VERBOSE_FLAGS)", "--target", "aarch64-apple-ios", "--target", "aarch64-apple-ios-sim", "--target", "x86_64-apple-ios", "-p", "liveview-native-core"]
+dependencies = ["install-targets"]
+
+[tasks.build-watchos]
+workspace = false
+category = "Build"
+description = "Compiles for all targets needed to produce a universal library for watchOS"
+command = "rustup"
+args = ["run", "${CARGO_MAKE_TOOLCHAIN}", "cargo", "build", "@@remove-empty(CARGO_MAKE_CARGO_VERBOSE_FLAGS)", "-Z", "build-std", "--target", "arm64_32-apple-watchos", "--target", "armv7k-apple-watchos", "--target", "aarch64-apple-watchos-sim", "--target", "x86_64-apple-watchos-sim", "-p", "liveview-native-core"]
 dependencies = ["install-targets"]
 
 # different architectures for the same platform need to be lipo'd together before going into the xcframework
@@ -178,6 +189,22 @@ args = [
 	"${CARGO_TARGET_DIR}/universal-ios-sim-libliveview_native_core.a",
 	"${CARGO_TARGET_DIR}/aarch64-apple-ios-sim/debug/libliveview_native_core.a",
 	"${CARGO_TARGET_DIR}/x86_64-apple-ios/debug/libliveview_native_core.a",
+]
+
+[tasks.lipo-watchos]
+worksapce = false
+category = "Packaging"
+description = "Creates universal binary for watchOS Simulator"
+command = "xcrun"
+args = [
+	"lipo",
+	"-create",
+	"-output",
+	"${CARGO_TARGET_DIR}/universal-watchos-libliveview_native_core.a",
+	"${CARGO_TARGET_DIR}/arm64_32-apple-watchos/debug/libliveview_native_core.a",
+	"${CARGO_TARGET_DIR}/armv7k-apple-watchos/debug/libliveview_native_core.a",
+	"${CARGO_TARGET_DIR}/aarch64-apple-watchos-sim/debug/libliveview_native_core.a",
+	"${CARGO_TARGET_DIR}/x86_64-apple-watchos-sim/debug/libliveview_native_core.a",
 ]
 
 [tasks.install-targets]


### PR DESCRIPTION
Extends `Makefile.toml` for watchOS builds.

I was unable to get tvOS to build (https://github.com/rust-lang/rust/pull/103503).