### PR TITLE
Fix generating incorrect patch list when adding an element

### DIFF
--- a/crates/core/c_src/include/LiveViewNativeCore.h
+++ b/crates/core/c_src/include/LiveViewNativeCore.h
@@ -56,6 +56,8 @@ enum __ChangeType {
   ChangeTypeRemove = 2,
 } __attribute__((enum_extensibility(closed)));
 
+typedef enum __ChangeType __ChangeType;
+
 extern void __liveview_native_core$AttributeVec$drop(_AttributeVec vec);
 
 extern _RustString __liveview_native_core$Document$to_string(__Document doc);

--- a/crates/core/src/diff/diff.rs
+++ b/crates/core/src/diff/diff.rs
@@ -100,13 +100,10 @@ pub fn diff(old_document: &Document, new_document: &Document) -> VecDeque<Patch>
         node: new_document.root(),
     }]);
     loop {
-        match (dbg!(old_next.pop_front()), dbg!(new_next.pop_front())) {
+        match (old_next.pop_front(), new_next.pop_front()) {
             // We're at the same position in both trees, so examine the details of the node under the cursor
             (Some(old_cursor), Some(new_cursor)) if old_cursor == new_cursor => {
-                match (
-                    dbg!(old_cursor.node(old_document)),
-                    dbg!(new_cursor.node(new_document)),
-                ) {
+                match (old_cursor.node(old_document), new_cursor.node(new_document)) {
                     // This was the root node, so move the cursor down a level and start walking the children
                     (Node::Root, Node::Root) => {
                         let old_children = old_document.children(old_cursor.node);
@@ -369,7 +366,9 @@ pub fn diff(old_document: &Document, new_document: &Document) -> VecDeque<Patch>
             (None, Some(new_cursor)) => {
                 patches.push_back(Patch::Move(MoveTo::Node(old_document.root())));
                 // Traverse the old tree based on the new_cursor path until we get to its immediate parent
-                for index in new_cursor.path.iter().copied() {
+                // Skip the last index in the new_cursor path, because that's the index of the
+                // new_cursor node (c in the diagram above), which does not yet exist in the tree.
+                for index in new_cursor.path[..new_cursor.path.len() - 1].iter().copied() {
                     patches.push_back(Patch::Move(MoveTo::Child(index as u32)));
                 }
                 patches.push_back(Patch::PushCurrent);

--- a/crates/core/tests/diff.rs
+++ b/crates/core/tests/diff.rs
@@ -247,3 +247,20 @@ fn issue3_regression_test() {
 
     assert_eq!(prev.to_string(), next.to_string());
 }
+
+#[test]
+fn diff_add_child_oob() {
+    let mut orig = Document::parse("<a></a>").unwrap();
+    let new = Document::parse("<a><b></b></a>").unwrap();
+
+    let mut patches = diff::diff(&orig, &new);
+
+    let mut editor = orig.edit();
+    let mut stack = vec![];
+    for patch in patches.drain(..) {
+        patch.apply(&mut editor, &mut stack);
+    }
+    editor.finish();
+
+    assert_eq!(orig.to_string(), new.to_string());
+}


### PR DESCRIPTION
Previously, merging `<a><b /></a>` into `<a></a>` would result in a panic due to an out-of-bounds access, since the generated patch list looked like:
- move to root
- move to child 0
- move to child 0
- push current
- ...

Applying that patch list would panic, since there is no child 0 of `<a>` yet (the push current op being what creates it).